### PR TITLE
dotenvs have no "ENV " prefix on keys

### DIFF
--- a/config/metabase_database.env.example
+++ b/config/metabase_database.env.example
@@ -1,8 +1,8 @@
-ENV MB_DB_TYPE=postgres
-ENV MB_DB_DBNAME=metabase
-ENV MB_DB_PORT=54320
-ENV MB_DB_USER=metabase
-ENV MB_DB_PASS=<put_here_the_password_for_the_metabase_user>
+MB_DB_TYPE=postgres
+MB_DB_DBNAME=metabase
+MB_DB_PORT=54320
+MB_DB_USER=metabase
+MB_DB_PASS=<put_here_the_password_for_the_metabase_user>
 # Make sure the firewall at the database server allows connections to port 54320
-ENV MB_DB_HOST=<put here the IP address for the Metabase database server e.g. 00.000.000.00>
-ENV MB_ENCRYPTION_SECRET_KEY=<Add a random string here as the secret>
+MB_DB_HOST=<put here the IP address for the Metabase database server e.g. 00.000.000.00>
+MB_ENCRYPTION_SECRET_KEY=<Add a random string here as the secret>


### PR DESCRIPTION
dotenvs have
```
key=value
key2=value2
...
```
not
```
ENV key=value
ENV key2=value2
...
```
style...

This fixes #1 